### PR TITLE
feat(spec): add .sourceos/manifest.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
         run: python src/sourceos_boot/validate_boot_release_set.py examples/boot-release-set.example.json
       - name: Run tests
         run: |
-          python -m pip install --upgrade pip pytest
+          python -m pip install --upgrade pip pytest jsonschema
           python -m pytest

--- a/.sourceos/manifest.json
+++ b/.sourceos/manifest.json
@@ -1,0 +1,25 @@
+{
+  "repo": "SourceOS-Linux/sourceos-boot",
+  "domain": "boot",
+  "specVersion": "0.1.0",
+  "ownedSchemas": [
+    "BootReleaseSet"
+  ],
+  "syncEngines": [],
+  "sourceChannels": [],
+  "policyClasses": [
+    "critical"
+  ],
+  "auditEvents": [
+    "boot.rollback.planned",
+    "boot.rollback.applied",
+    "boot.rollback.denied",
+    "boot.chain.validated"
+  ],
+  "dangerousSurfaces": [
+    "boot.efi_vars_mutable",
+    "boot.rollback.forced",
+    "boot.generation.deletion"
+  ],
+  "notes": "Asahi Linux boot chain model for Apple Silicon. efiVarsMutable must always be false — mutating EFI vars on M1/M2 can prevent macOS from booting."
+}


### PR DESCRIPTION
## Summary

- Adds `.sourceos/manifest.json`: domain `boot`, ownedSchemas `[BootReleaseSet]`, policyClass `critical`.
- Documents dangerous surfaces: `boot.efi_vars_mutable`, `boot.rollback.forced`, `boot.generation.deletion`.
- Notes the Asahi invariant: `efiVarsMutable` must always be `false`.

## Test plan

- [ ] `python3 -m pytest tests/ -q` passes unchanged